### PR TITLE
[hotfix] Fixed players list alignment

### DIFF
--- a/src/components/players/list/index.module.scss
+++ b/src/components/players/list/index.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex: 2;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
   height: calc(100vh - 90px);
   overflow-y: auto;
   background-color: $white;


### PR DESCRIPTION
If you were to pick `Golden State Warriors` as your team and scroll to the bottom the gaps in between are large

_master_:
<img width="988" alt="Screen Shot 2020-05-22 at 12 15 15 PM" src="https://user-images.githubusercontent.com/623755/82688642-3a0fe800-9c27-11ea-8d2f-5d740d1ac43a.png">


This hotfix fixes this issue